### PR TITLE
FEAT: Add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @NurRobin

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Description
+
+<!-- Briefly describe what was done -->
+
+## Checklist
+
+- [ ] Tests run locally (`mvn test` / `mvn verify`)
+- [ ] Changelog added to `docs/changelog/`
+- [ ] Branch name follows convention (`feature/...`, `fix/...`, etc.)
+- [ ] Documentation updated if necessary


### PR DESCRIPTION
This pull request introduces two small but important changes to project configuration files. The `.github/CODEOWNERS` file now assigns ownership of the `.github/` directory, and a new pull request template has been added to standardize PR descriptions and checklists.

Process and ownership improvements:

* Added `.github/pull_request_template.md` to provide a standard template for pull requests, including sections for description and a checklist to ensure best practices are followed.
* Updated `.github/CODEOWNERS` to assign ownership of the `.github/` directory to `@NurRobin`.