### PR TITLE
fix/paths-filter-param-typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           # Compare against previous commit, not base branch
           base: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.head.sha }}
-          initial_fetch_depth: 2
+          initial-fetch-depth: 2
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           # Compare against previous commit, not base branch
           base: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.head.sha }}
-          initial_fetch_depth: 2
+          initial-fetch-depth: 2
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           # Compare against previous commit, not base branch
           base: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.head.sha }}
-          initial_fetch_depth: 2
+          initial-fetch-depth: 2
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -42,14 +42,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Check for code changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          # Compare against previous commit (HEAD~1), not base branch
-          base: HEAD~1
-          initial_fetch_depth: 2
+          # Compare against previous commit for push events
+          base: ${{ github.event.before }}
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/e2e-runtime-test.yml
+++ b/.github/workflows/e2e-runtime-test.yml
@@ -64,6 +64,10 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@v3
         with:
+          # Compare against PR base for accurate change detection
+          base: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          initial-fetch-depth: 2
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/runtime-test.yml
+++ b/.github/workflows/runtime-test.yml
@@ -42,7 +42,7 @@ jobs:
           # Compare against previous commit, not base branch
           base: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.head.sha }}
-          initial_fetch_depth: 2
+          initial-fetch-depth: 2
           filters: |
             relevant:
               - '**.java'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,14 +31,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Check for code changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          # Compare against previous commit (HEAD~1), not base branch
-          base: HEAD~1
-          initial_fetch_depth: 2
+          # Compare against previous commit for push events
+          base: ${{ github.event.before }}
           filters: |
             relevant:
               - '**.java'


### PR DESCRIPTION
Fix dorny/paths-filter parameter name typo across all workflows.
Changed initial_fetch_depth to initial-fetch-depth (hyphen).
Added missing base/ref/initial-fetch-depth params in e2e-runtime-test.yml.

This fixes the branch detection error when running on feature branches:
'Error: The process /usr/bin/git failed with exit code 128'