### PR TITLE
feat: Add OpenAPI support with machine-readable documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,14 @@ jobs:
         if: ${{ inputs.skip-tests }}
         run: mvn -B -ntp clean package -DskipTests -T 1C
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && !inputs.skip-tests }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/surefire-reports/*.xml
+          flags: backend
+
       - name: Upload built jar
         id: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Run tests with coverage (parallel)
         run: mvn -B -ntp verify -T 1C
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/surefire-reports/*.xml
+          flags: backend
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -219,7 +219,7 @@ These principles guide every feature and decision:
 | **Damage Heatmaps** | Medium | M | ✅ Done | Identify PvP hotspots and mob danger zones |
 | **Resource-Specific Heatmaps** | Medium | M | ✅ Done | Track diamond, iron, gold, ancient debris separately |
 | **OpenAPI-Published API** | High | M | ⚠️ Partial | Machine-readable docs exposed for external tooling |
-| **Time-Range Filters** | Medium | M | ⏳ Todo | Query "last 6h", "today", "this week" |
+| **Time-Range Filters** | Medium | M | ✅ Done | Query "last 6h", "today", "this week" |
 | **Biome-Filtered Views** | Low | S | ⏳ Todo | Filter any heatmap by biome type |
 | **In-Game GUI** | High | L | ✅ Done | Rich chest-menu interface with visual insights |
 | **Live Activity Dashboard** | Medium | M | ⚠️ Partial | "Who's farming what right now" real-time view |

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -218,6 +218,7 @@ These principles guide every feature and decision:
 | **Movement Heatmaps** | Medium | M | ✅ Done | Visualize player travel and popular zones |
 | **Damage Heatmaps** | Medium | M | ✅ Done | Identify PvP hotspots and mob danger zones |
 | **Resource-Specific Heatmaps** | Medium | M | ✅ Done | Track diamond, iron, gold, ancient debris separately |
+| **OpenAPI-Published API** | High | M | ⚠️ Partial | Machine-readable docs exposed for external tooling |
 | **Time-Range Filters** | Medium | M | ⏳ Todo | Query "last 6h", "today", "this week" |
 | **Biome-Filtered Views** | Low | S | ⏳ Todo | Filter any heatmap by biome type |
 | **In-Game GUI** | High | L | ✅ Done | Rich chest-menu interface with visual insights |

--- a/docs/changelog/0.13.0.md
+++ b/docs/changelog/0.13.0.md
@@ -1,0 +1,33 @@
+# Changelog - Version 0.13.0
+
+**Release Date:** 2025-11-27
+
+## 🎯 Summary
+
+Adds a published OpenAPI 3.1 document for the HTTP API so external tools and SDK generators can consume the contract automatically.
+
+---
+
+## ✨ New Features
+
+### OpenAPI Document + Endpoint
+- New `GET /openapi.json` endpoint (no auth) serves a full OpenAPI 3.1 document describing all HTTP endpoints.
+- Document includes schemas for stats, moments, heatmaps (with grid size), timeline ranges, health snapshots, social pairs, and death replays.
+- Documents human-readable time filters (`from`/`to`) alongside legacy parameters.
+
+### Documentation Updates
+- `docs/API.md` now references `/openapi.json`, clarifies heatmap bin fields (`x`, `z`, `gridSize`) and hotspot responses, and documents full health snapshot fields (TPS, memory, hot chunks).
+
+---
+
+## 🔧 Technical Notes
+
+- OpenAPI is generated at runtime by `OpenApiDocument` and versioned using the plugin version.
+- Endpoint intentionally bypasses API key auth to ease discovery by tools like Swagger UI, Insomnia, and Postman.
+
+---
+
+## 📖 Upgrade Notes
+
+- No configuration or database changes required.
+- API consumers can now point generators at `http://<host>:<port>/openapi.json`.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.nurrobin</groupId>
     <artifactId>smpstats</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <name>SMPStats</name>
     <description>Paper 1.21.x player statistics plugin</description>
 

--- a/src/main/java/de/nurrobin/smpstats/api/ApiServer.java
+++ b/src/main/java/de/nurrobin/smpstats/api/ApiServer.java
@@ -13,6 +13,7 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import org.bukkit.plugin.PluginDescriptionFile;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,7 +51,12 @@ public class ApiServer {
         this.heatmapService = heatmapService;
         this.timelineService = timelineService;
         this.serverHealthService = serverHealthService;
-        this.openApiDocument = new OpenApiDocument(settings, plugin.getDescription().getVersion());
+        this.openApiDocument = new OpenApiDocument(settings, resolvePluginVersion(plugin));
+    }
+
+    private String resolvePluginVersion(SMPStats plugin) {
+        PluginDescriptionFile description = plugin != null ? plugin.getDescription() : null;
+        return description != null ? description.getVersion() : "unknown";
     }
 
     public void start() {
@@ -110,7 +116,7 @@ public class ApiServer {
     }
 
     private void sendJson(HttpExchange exchange, int status, Object body) throws IOException {
-        byte[] data = gson.toJson(body).getBytes();
+        byte[] data = gson.toJson(body).getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
         exchange.sendResponseHeaders(status, data.length);
         try (OutputStream os = exchange.getResponseBody()) {

--- a/src/main/java/de/nurrobin/smpstats/api/OpenApiDocument.java
+++ b/src/main/java/de/nurrobin/smpstats/api/OpenApiDocument.java
@@ -333,7 +333,7 @@ class OpenApiDocument {
                         "x", Map.of("type", "integer", "description", "Grid x index"),
                         "z", Map.of("type", "integer", "description", "Grid z index"),
                         "gridSize", Map.of("type", "integer", "description", "Bin size in blocks"),
-                        "count", Map.of("type", "number")
+                        "count", Map.of("type", "number", "description", "Weighted hits recorded in the bin (decay applied when configured)")
                 )
         ));
 

--- a/src/main/java/de/nurrobin/smpstats/api/OpenApiDocument.java
+++ b/src/main/java/de/nurrobin/smpstats/api/OpenApiDocument.java
@@ -1,0 +1,537 @@
+package de.nurrobin.smpstats.api;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import de.nurrobin.smpstats.Settings;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a lightweight OpenAPI 3.1 document for the HTTP API so external tools can ingest it.
+ */
+class OpenApiDocument {
+    private final Settings settings;
+    private final String version;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    OpenApiDocument(Settings settings, String version) {
+        this.settings = settings;
+        this.version = version;
+    }
+
+    String toJson() {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("openapi", "3.1.0");
+        root.put("info", info());
+        root.put("servers", servers());
+        root.put("security", secured());
+        root.put("paths", paths());
+        root.put("components", components());
+        return gson.toJson(root);
+    }
+
+    private Map<String, Object> info() {
+        Map<String, Object> info = new LinkedHashMap<>();
+        info.put("title", "SMPStats API");
+        info.put("summary", "Minecraft analytics and monitoring API");
+        info.put("version", version);
+        info.put("description", """
+                HTTP API exposed by the SMPStats plugin. All endpoints require the X-API-Key header unless noted otherwise.
+                """);
+        return info;
+    }
+
+    private List<Map<String, Object>> servers() {
+        Map<String, Object> server = new LinkedHashMap<>();
+        server.put("url", "http://{host}:{port}");
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("host", Map.of("default", settings.getApiBindAddress()));
+        variables.put("port", Map.of("default", Integer.toString(settings.getApiPort())));
+        server.put("variables", variables);
+        return List.of(server);
+    }
+
+    private Map<String, Object> paths() {
+        Map<String, Object> paths = new LinkedHashMap<>();
+
+        paths.put("/openapi.json", Map.of(
+                "get", Map.of(
+                        "summary", "Download OpenAPI document",
+                        "description", "Machine-readable API description",
+                        "responses", Map.of(
+                                "200", jsonResponse("OpenAPI document", Map.of("type", "object"))
+                        ),
+                        "security", List.of()
+                )
+        ));
+
+        paths.put("/stats/{playerId}", Map.of(
+                "get", Map.of(
+                        "summary", "Get stats for a player",
+                        "parameters", List.of(
+                                pathParam("playerId", "Player UUID", "string", "uuid")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Player stats", ref("StatsRecord")),
+                                "400", textResponse("Invalid UUID"),
+                                "404", textResponse("Player not found")
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/stats/all", Map.of(
+                "get", Map.of(
+                        "summary", "List stats for all players",
+                        "responses", Map.of(
+                                "200", jsonResponse("Stats for all players", arraySchema(ref("StatsRecord")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/online", Map.of(
+                "get", Map.of(
+                        "summary", "List currently online player names",
+                        "responses", Map.of(
+                                "200", jsonResponse("Online player names", arraySchema(Map.of("type", "string")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/moments/recent", Map.of(
+                "get", Map.of(
+                        "summary", "Recent moments",
+                        "parameters", List.of(
+                                queryParam("limit", "Maximum entries to return", "integer"),
+                                queryParam("from", "Human-readable start (6h, today, this_week)", "string"),
+                                queryParam("since", "Start timestamp (epoch millis)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Recent moments", arraySchema(ref("MomentEntry")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/moments/query", Map.of(
+                "get", Map.of(
+                        "summary", "Query moments",
+                        "parameters", List.of(
+                                queryParam("limit", "Maximum entries to return", "integer"),
+                                queryParam("from", "Human-readable start (6h, today, this_week)", "string"),
+                                queryParam("since", "Start timestamp (epoch millis)", "integer"),
+                                queryParam("type", "Moment type id", "string"),
+                                queryParam("player", "Player UUID to filter", "string")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Filtered moments", arraySchema(ref("MomentEntry")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/moments/stream", Map.of(
+                "get", Map.of(
+                        "summary", "Server-sent events stream of recent moments",
+                        "parameters", List.of(
+                                queryParam("limit", "Maximum events to seed the stream with", "integer"),
+                                queryParam("from", "Human-readable start (6h, today, this_week)", "string"),
+                                queryParam("since", "Start timestamp (epoch millis)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", Map.of(
+                                        "description", "SSE stream",
+                                        "content", Map.of(
+                                                "text/event-stream", Map.of(
+                                                        "schema", Map.of("type", "string"),
+                                                        "examples", Map.of("event", Map.of(
+                                                                "summary", "Example SSE payload",
+                                                                "value", "data: {\"type\":\"DIAMOND_RUN\",...}\\n\\n"
+                                                        ))
+                                                )
+                                        )
+                                )
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/heatmap/{type}", Map.of(
+                "get", Map.of(
+                        "summary", "Heatmap bins",
+                        "parameters", List.of(
+                                pathParam("type", "Heatmap type (MINING, DEATH, POSITION, DAMAGE)", "string", null),
+                                queryParam("world", "World name (default: world)", "string"),
+                                queryParam("from", "Human-readable start", "string"),
+                                queryParam("to", "Human-readable end", "string"),
+                                queryParam("since", "Start timestamp (epoch millis)", "integer"),
+                                queryParam("until", "End timestamp (epoch millis)", "integer"),
+                                queryParam("decay", "Half-life in hours", "number"),
+                                queryParam("grid", "Grid size (8/16/32/64)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Heatmap bins", arraySchema(ref("HeatmapBin"))),
+                                "400", textResponse("Invalid type")
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/heatmap/hotspots/{type}", Map.of(
+                "get", Map.of(
+                        "summary", "Named hotspot counters",
+                        "parameters", List.of(
+                                pathParam("type", "Heatmap type", "string", null)
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Hotspot counts", ref("HeatmapHotspots"))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/timeline/{playerId}", Map.of(
+                "get", Map.of(
+                        "summary", "Per-day timeline snapshots",
+                        "parameters", List.of(
+                                pathParam("playerId", "Player UUID", "string", "uuid"),
+                                queryParam("limit", "Number of days to return (default 30)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Timeline snapshots", arraySchema(ref("TimelineEntry"))),
+                                "400", textResponse("Invalid UUID")
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/timeline/range/{playerId}", Map.of(
+                "get", Map.of(
+                        "summary", "Range delta over timeline period",
+                        "parameters", List.of(
+                                pathParam("playerId", "Player UUID", "string", "uuid"),
+                                queryParam("from", "Human-readable start (6h, today, this_week)", "string"),
+                                queryParam("days", "Number of days to include (default 7)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Range totals", ref("TimelineDelta")),
+                                "400", textResponse("Invalid UUID")
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/timeline/leaderboard", Map.of(
+                "get", Map.of(
+                        "summary", "Timeline leaderboard",
+                        "parameters", List.of(
+                                queryParam("from", "Human-readable start (6h, today, this_week)", "string"),
+                                queryParam("days", "Number of days to include (default 7)", "integer"),
+                                queryParam("limit", "Number of players (default 20)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Leaderboard rows", arraySchema(ref("TimelineDelta")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/social/top", Map.of(
+                "get", Map.of(
+                        "summary", "Top shared playtime pairs",
+                        "parameters", List.of(
+                                queryParam("limit", "Number of rows (default 50)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Pairs ordered by shared time", arraySchema(ref("SocialPair")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/death/replay", Map.of(
+                "get", Map.of(
+                        "summary", "Recent death replays",
+                        "parameters", List.of(
+                                queryParam("limit", "Number of entries (default 20)", "integer")
+                        ),
+                        "responses", Map.of(
+                                "200", jsonResponse("Death replay buffer", arraySchema(ref("DeathReplayEntry")))
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        paths.put("/health", Map.of(
+                "get", Map.of(
+                        "summary", "Latest server health snapshot",
+                        "responses", Map.of(
+                                "200", jsonResponse("Health snapshot", ref("HealthSnapshot")),
+                                "404", textResponse("No samples yet")
+                        ),
+                        "security", secured()
+                )
+        ));
+
+        return paths;
+    }
+
+    private Map<String, Object> components() {
+        Map<String, Object> schemas = new LinkedHashMap<>();
+        schemas.put("StatsRecord", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("uuid", Map.of("type", "string", "format", "uuid")),
+                        Map.entry("name", Map.of("type", "string")),
+                        Map.entry("firstJoin", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("lastJoin", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("playtimeMillis", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("deaths", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("lastDeathCause", Map.of("type", "string", "nullable", true)),
+                        Map.entry("playerKills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("mobKills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocksPlaced", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocksBroken", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("distanceOverworld", Map.of("type", "number")),
+                        Map.entry("distanceNether", Map.of("type", "number")),
+                        Map.entry("distanceEnd", Map.of("type", "number")),
+                        Map.entry("biomesVisited", Map.of("type", "array", "items", Map.of("type", "string"))),
+                        Map.entry("damageDealt", Map.of("type", "number")),
+                        Map.entry("damageTaken", Map.of("type", "number")),
+                        Map.entry("itemsCrafted", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("itemsConsumed", Map.of("type", "integer", "format", "int64"))
+                )
+        ));
+
+        schemas.put("MomentEntry", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("id", Map.of("type", "integer", "format", "int64", "nullable", true)),
+                        Map.entry("playerId", Map.of("type", "string", "format", "uuid")),
+                        Map.entry("type", Map.of("type", "string")),
+                        Map.entry("title", Map.of("type", "string")),
+                        Map.entry("detail", Map.of("type", "string")),
+                        Map.entry("payload", Map.of("type", "string", "nullable", true)),
+                        Map.entry("world", Map.of("type", "string")),
+                        Map.entry("x", Map.of("type", "integer")),
+                        Map.entry("y", Map.of("type", "integer")),
+                        Map.entry("z", Map.of("type", "integer")),
+                        Map.entry("startedAt", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("endedAt", Map.of("type", "integer", "format", "int64"))
+                )
+        ));
+
+        schemas.put("HeatmapBin", Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "type", Map.of("type", "string"),
+                        "world", Map.of("type", "string"),
+                        "x", Map.of("type", "integer", "description", "Grid x index"),
+                        "z", Map.of("type", "integer", "description", "Grid z index"),
+                        "gridSize", Map.of("type", "integer", "description", "Bin size in blocks"),
+                        "count", Map.of("type", "number")
+                )
+        ));
+
+        schemas.put("HeatmapHotspots", Map.of(
+                "type", "object",
+                "additionalProperties", Map.of("type", "number"),
+                "description", "Map of hotspot name to weighted count"
+        ));
+
+        schemas.put("TimelineEntry", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("day", Map.of("type", "string", "description", "ISO date YYYY-MM-DD")),
+                        Map.entry("playtime_ms", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocks_broken", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocks_placed", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("player_kills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("mob_kills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("deaths", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("distance_overworld", Map.of("type", "number")),
+                        Map.entry("distance_nether", Map.of("type", "number")),
+                        Map.entry("distance_end", Map.of("type", "number")),
+                        Map.entry("damage_dealt", Map.of("type", "number")),
+                        Map.entry("damage_taken", Map.of("type", "number")),
+                        Map.entry("items_crafted", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("items_consumed", Map.of("type", "integer", "format", "int64"))
+                )
+        ));
+
+        schemas.put("TimelineDelta", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("from", Map.of("type", "string")),
+                        Map.entry("to", Map.of("type", "string")),
+                        Map.entry("uuid", Map.of("type", "string", "format", "uuid")),
+                        Map.entry("name", Map.of("type", "string")),
+                        Map.entry("playtime_ms", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocks_broken", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("blocks_placed", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("player_kills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("mob_kills", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("deaths", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("distance_overworld", Map.of("type", "number")),
+                        Map.entry("distance_nether", Map.of("type", "number")),
+                        Map.entry("distance_end", Map.of("type", "number")),
+                        Map.entry("damage_dealt", Map.of("type", "number")),
+                        Map.entry("damage_taken", Map.of("type", "number")),
+                        Map.entry("items_crafted", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("items_consumed", Map.of("type", "integer", "format", "int64"))
+                )
+        ));
+
+        schemas.put("SocialPair", Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "a", Map.of("type", "string", "format", "uuid"),
+                        "b", Map.of("type", "string", "format", "uuid"),
+                        "name_a", Map.of("type", "string"),
+                        "name_b", Map.of("type", "string"),
+                        "seconds", Map.of("type", "integer", "format", "int64"),
+                        "shared_kills", Map.of("type", "integer", "format", "int64"),
+                        "shared_player_kills", Map.of("type", "integer", "format", "int64"),
+                        "shared_mob_kills", Map.of("type", "integer", "format", "int64")
+                )
+        ));
+
+        schemas.put("DeathReplayEntry", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("timestamp", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("uuid", Map.of("type", "string", "format", "uuid")),
+                        Map.entry("name", Map.of("type", "string")),
+                        Map.entry("cause", Map.of("type", "string")),
+                        Map.entry("health", Map.of("type", "number")),
+                        Map.entry("world", Map.of("type", "string")),
+                        Map.entry("x", Map.of("type", "integer")),
+                        Map.entry("y", Map.of("type", "integer")),
+                        Map.entry("z", Map.of("type", "integer")),
+                        Map.entry("fallDistance", Map.of("type", "number")),
+                        Map.entry("nearbyPlayers", Map.of("type", "array", "items", Map.of("type", "string"))),
+                        Map.entry("nearbyMobs", Map.of("type", "array", "items", Map.of("type", "string"))),
+                        Map.entry("inventory", Map.of("type", "array", "items", Map.of("type", "string")))
+                )
+        ));
+
+        schemas.put("HealthSnapshot", Map.of(
+                "type", "object",
+                "properties", Map.ofEntries(
+                        Map.entry("timestamp", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("tps", Map.of("type", "number")),
+                        Map.entry("memoryUsed", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("memoryMax", Map.of("type", "integer", "format", "int64")),
+                        Map.entry("chunks", Map.of("type", "integer")),
+                        Map.entry("entities", Map.of("type", "integer")),
+                        Map.entry("hoppers", Map.of("type", "integer")),
+                        Map.entry("redstone", Map.of("type", "integer")),
+                        Map.entry("costIndex", Map.of("type", "number")),
+                        Map.entry("worlds", Map.of(
+                                "type", "object",
+                                "additionalProperties", ref("HealthWorldBreakdown")
+                        )),
+                        Map.entry("hotChunks", Map.of("type", "array", "items", ref("HealthHotChunk")))
+                )
+        ));
+
+        schemas.put("HealthWorldBreakdown", Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "chunks", Map.of("type", "integer"),
+                        "entities", Map.of("type", "integer"),
+                        "hoppers", Map.of("type", "integer"),
+                        "redstone", Map.of("type", "integer")
+                )
+        ));
+
+        schemas.put("HealthHotChunk", Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "world", Map.of("type", "string"),
+                        "x", Map.of("type", "integer"),
+                        "z", Map.of("type", "integer"),
+                        "entityCount", Map.of("type", "integer"),
+                        "tileEntityCount", Map.of("type", "integer"),
+                        "topOwner", Map.of("type", "string")
+                )
+        ));
+
+        Map<String, Object> components = new LinkedHashMap<>();
+        components.put("securitySchemes", Map.of(
+                "ApiKeyAuth", Map.of(
+                        "type", "apiKey",
+                        "in", "header",
+                        "name", "X-API-Key"
+                )
+        ));
+        components.put("schemas", schemas);
+        return components;
+    }
+
+    private List<Map<String, List<String>>> secured() {
+        return List.of(Map.of("ApiKeyAuth", List.of()));
+    }
+
+    private Map<String, Object> pathParam(String name, String description, String type, String format) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", type);
+        if (format != null) {
+            schema.put("format", format);
+        }
+        return Map.of(
+                "name", name,
+                "in", "path",
+                "required", true,
+                "schema", schema,
+                "description", description
+        );
+    }
+
+    private Map<String, Object> queryParam(String name, String description, String type) {
+        return Map.of(
+                "name", name,
+                "in", "query",
+                "required", false,
+                "schema", Map.of("type", type),
+                "description", description
+        );
+    }
+
+    private Map<String, Object> jsonResponse(String description, Map<String, Object> schema) {
+        return Map.of(
+                "description", description,
+                "content", Map.of(
+                        "application/json", Map.of(
+                                "schema", schema
+                        )
+                )
+        );
+    }
+
+    private Map<String, Object> textResponse(String description) {
+        return Map.of(
+                "description", description,
+                "content", Map.of(
+                        "text/plain", Map.of(
+                                "schema", Map.of("type", "string")
+                        )
+                )
+        );
+    }
+
+    private Map<String, Object> ref(String schema) {
+        return Map.of("$ref", "#/components/schemas/" + schema);
+    }
+
+    private Map<String, Object> arraySchema(Map<String, Object> items) {
+        return Map.of(
+                "type", "array",
+                "items", items
+        );
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SMPStats
-version: 0.10.0
+version: 0.13.0
 main: de.nurrobin.smpstats.SMPStats
 api-version: '1.21'
 author: nurrobin

--- a/src/test/java/de/nurrobin/smpstats/api/OpenApiDocumentTest.java
+++ b/src/test/java/de/nurrobin/smpstats/api/OpenApiDocumentTest.java
@@ -1,0 +1,699 @@
+package de.nurrobin.smpstats.api;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import de.nurrobin.smpstats.Settings;
+import de.nurrobin.smpstats.health.HealthThresholds;
+import de.nurrobin.smpstats.skills.SkillWeights;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Comprehensive tests for OpenApiDocument to validate the generated OpenAPI 3.1 specification.
+ */
+class OpenApiDocumentTest {
+
+    private Settings settings;
+    private OpenApiDocument document;
+    private JsonObject openApiJson;
+
+    @BeforeEach
+    void setUp() {
+        settings = new Settings(
+                true, true, true, true, true, true, true,
+                true, "0.0.0.0", 8080, "test-api-key", 1,
+                new SkillWeights(
+                        new SkillWeights.MiningWeights(0),
+                        new SkillWeights.CombatWeights(0, 0, 0),
+                        new SkillWeights.ExplorationWeights(0, 0),
+                        new SkillWeights.BuilderWeights(0),
+                        new SkillWeights.FarmerWeights(0, 0)
+                ),
+                true, 0L, 0L, true, 1, 1.0, List.of(), List.of(),
+                true, 1, 1, true, true, true, 1, 1, true, 1, 0, 0, 0, 0,
+                HealthThresholds.defaults(), true, 1, 1, "", 1, 1,
+                Settings.DashboardSettings.defaults()
+        );
+        document = new OpenApiDocument(settings, "1.0.0");
+        openApiJson = JsonParser.parseString(document.toJson()).getAsJsonObject();
+    }
+
+    @Nested
+    class OpenApiStructure {
+
+        @Test
+        void hasValidOpenApiVersion() {
+            assertTrue(openApiJson.has("openapi"));
+            assertEquals("3.1.0", openApiJson.get("openapi").getAsString());
+        }
+
+        @Test
+        void hasRequiredTopLevelFields() {
+            assertTrue(openApiJson.has("info"), "Missing 'info' field");
+            assertTrue(openApiJson.has("servers"), "Missing 'servers' field");
+            assertTrue(openApiJson.has("paths"), "Missing 'paths' field");
+            assertTrue(openApiJson.has("components"), "Missing 'components' field");
+            assertTrue(openApiJson.has("security"), "Missing 'security' field");
+        }
+
+        @Test
+        void infoSectionContainsRequiredFields() {
+            JsonObject info = openApiJson.getAsJsonObject("info");
+            assertNotNull(info);
+            assertTrue(info.has("title"));
+            assertTrue(info.has("version"));
+            assertTrue(info.has("description"));
+
+            assertEquals("SMPStats API", info.get("title").getAsString());
+            assertEquals("1.0.0", info.get("version").getAsString());
+        }
+
+        @Test
+        void serverVariablesUseSettingsValues() {
+            JsonArray servers = openApiJson.getAsJsonArray("servers");
+            assertFalse(servers.isEmpty());
+
+            JsonObject server = servers.get(0).getAsJsonObject();
+            JsonObject variables = server.getAsJsonObject("variables");
+
+            assertEquals("0.0.0.0", variables.getAsJsonObject("host").get("default").getAsString());
+            assertEquals("8080", variables.getAsJsonObject("port").get("default").getAsString());
+        }
+    }
+
+    @Nested
+    class SecurityDefinitions {
+
+        @Test
+        void definesApiKeySecurityScheme() {
+            JsonObject components = openApiJson.getAsJsonObject("components");
+            JsonObject securitySchemes = components.getAsJsonObject("securitySchemes");
+
+            assertTrue(securitySchemes.has("ApiKeyAuth"));
+            JsonObject apiKeyAuth = securitySchemes.getAsJsonObject("ApiKeyAuth");
+            assertEquals("apiKey", apiKeyAuth.get("type").getAsString());
+            assertEquals("header", apiKeyAuth.get("in").getAsString());
+            assertEquals("X-API-Key", apiKeyAuth.get("name").getAsString());
+        }
+
+        @Test
+        void globalSecurityRequiresApiKey() {
+            JsonArray security = openApiJson.getAsJsonArray("security");
+            assertFalse(security.isEmpty());
+
+            JsonObject securityRequirement = security.get(0).getAsJsonObject();
+            assertTrue(securityRequirement.has("ApiKeyAuth"));
+        }
+
+        @Test
+        void openApiEndpointIsPublic() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject openApiPath = paths.getAsJsonObject("/openapi.json");
+            JsonObject getOp = openApiPath.getAsJsonObject("get");
+
+            assertTrue(getOp.has("security"));
+            JsonArray security = getOp.getAsJsonArray("security");
+            assertTrue(security.isEmpty(), "OpenAPI endpoint should have empty security array");
+        }
+
+        @Test
+        void protectedEndpointsHaveSecurityDefined() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            Set<String> publicEndpoints = Set.of("/openapi.json");
+            for (String pathKey : paths.keySet()) {
+                if (publicEndpoints.contains(pathKey)) {
+                    continue;
+                }
+                JsonObject pathItem = paths.getAsJsonObject(pathKey);
+                for (String method : pathItem.keySet()) {
+                    JsonObject operation = pathItem.getAsJsonObject(method);
+                    assertTrue(operation.has("security"),
+                            "Endpoint " + pathKey + " (" + method + ") should have security defined");
+                }
+            }
+        }
+    }
+
+    @Nested
+    class EndpointPaths {
+
+        private static final Set<String> EXPECTED_PATHS = Set.of(
+                "/openapi.json",
+                "/stats/{playerId}",
+                "/stats/all",
+                "/online",
+                "/moments/recent",
+                "/moments/query",
+                "/moments/stream",
+                "/heatmap/{type}",
+                "/heatmap/hotspots/{type}",
+                "/timeline/{playerId}",
+                "/timeline/range/{playerId}",
+                "/timeline/leaderboard",
+                "/social/top",
+                "/death/replay",
+                "/health"
+        );
+
+        @Test
+        void allExpectedPathsAreDefined() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            for (String expectedPath : EXPECTED_PATHS) {
+                assertTrue(paths.has(expectedPath),
+                        "Missing expected path: " + expectedPath);
+            }
+        }
+
+        @Test
+        void noUnexpectedPathsExist() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            for (String pathKey : paths.keySet()) {
+                assertTrue(EXPECTED_PATHS.contains(pathKey),
+                        "Unexpected path found: " + pathKey);
+            }
+        }
+
+        @Test
+        void allPathsHaveGetMethod() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            for (String pathKey : paths.keySet()) {
+                JsonObject pathItem = paths.getAsJsonObject(pathKey);
+                assertTrue(pathItem.has("get"),
+                        "Path " + pathKey + " should have GET method");
+            }
+        }
+
+        @Test
+        void allPathsHaveSummary() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            for (String pathKey : paths.keySet()) {
+                JsonObject pathItem = paths.getAsJsonObject(pathKey);
+                JsonObject getOp = pathItem.getAsJsonObject("get");
+                assertTrue(getOp.has("summary"),
+                        "Path " + pathKey + " should have a summary");
+                assertFalse(getOp.get("summary").getAsString().isBlank(),
+                        "Path " + pathKey + " summary should not be blank");
+            }
+        }
+
+        @Test
+        void allPathsHaveResponses() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            for (String pathKey : paths.keySet()) {
+                JsonObject pathItem = paths.getAsJsonObject(pathKey);
+                JsonObject getOp = pathItem.getAsJsonObject("get");
+                assertTrue(getOp.has("responses"),
+                        "Path " + pathKey + " should have responses defined");
+                assertFalse(getOp.getAsJsonObject("responses").keySet().isEmpty(),
+                        "Path " + pathKey + " should have at least one response");
+            }
+        }
+    }
+
+    @Nested
+    class ParameterDefinitions {
+
+        @Test
+        void statsPlayerIdPathParameterIsCorrect() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject statsPath = paths.getAsJsonObject("/stats/{playerId}");
+            JsonArray parameters = statsPath.getAsJsonObject("get").getAsJsonArray("parameters");
+
+            assertTrue(parameters.size() >= 1);
+            JsonObject playerIdParam = parameters.get(0).getAsJsonObject();
+            assertEquals("playerId", playerIdParam.get("name").getAsString());
+            assertEquals("path", playerIdParam.get("in").getAsString());
+            assertTrue(playerIdParam.get("required").getAsBoolean());
+            assertEquals("uuid", playerIdParam.getAsJsonObject("schema").get("format").getAsString());
+        }
+
+        @Test
+        void heatmapTypePathParameterIsDefined() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject heatmapPath = paths.getAsJsonObject("/heatmap/{type}");
+            JsonArray parameters = heatmapPath.getAsJsonObject("get").getAsJsonArray("parameters");
+
+            boolean hasTypeParam = false;
+            for (JsonElement param : parameters) {
+                JsonObject p = param.getAsJsonObject();
+                if ("type".equals(p.get("name").getAsString()) && "path".equals(p.get("in").getAsString())) {
+                    hasTypeParam = true;
+                    assertTrue(p.get("required").getAsBoolean());
+                    break;
+                }
+            }
+            assertTrue(hasTypeParam, "Heatmap endpoint should have 'type' path parameter");
+        }
+
+        @Test
+        void momentsQueryHasExpectedQueryParameters() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject momentsQuery = paths.getAsJsonObject("/moments/query");
+            JsonArray parameters = momentsQuery.getAsJsonObject("get").getAsJsonArray("parameters");
+
+            Set<String> expectedParams = Set.of("limit", "from", "since", "type", "player");
+            Set<String> foundParams = new HashSet<>();
+
+            for (JsonElement param : parameters) {
+                JsonObject p = param.getAsJsonObject();
+                foundParams.add(p.get("name").getAsString());
+                assertEquals("query", p.get("in").getAsString());
+                assertFalse(p.get("required").getAsBoolean(), "Query parameters should not be required");
+            }
+
+            assertEquals(expectedParams, foundParams);
+        }
+
+        @Test
+        void heatmapEndpointHasAllQueryParameters() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject heatmapPath = paths.getAsJsonObject("/heatmap/{type}");
+            JsonArray parameters = heatmapPath.getAsJsonObject("get").getAsJsonArray("parameters");
+
+            Set<String> expectedQueryParams = Set.of("world", "from", "to", "since", "until", "decay", "grid");
+            Set<String> foundQueryParams = new HashSet<>();
+
+            for (JsonElement param : parameters) {
+                JsonObject p = param.getAsJsonObject();
+                if ("query".equals(p.get("in").getAsString())) {
+                    foundQueryParams.add(p.get("name").getAsString());
+                }
+            }
+
+            assertEquals(expectedQueryParams, foundQueryParams);
+        }
+
+        @Test
+        void timelineLeaderboardHasFromAndDaysParameters() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject leaderboard = paths.getAsJsonObject("/timeline/leaderboard");
+            JsonArray parameters = leaderboard.getAsJsonObject("get").getAsJsonArray("parameters");
+
+            Set<String> foundParams = new HashSet<>();
+            for (JsonElement param : parameters) {
+                JsonObject p = param.getAsJsonObject();
+                foundParams.add(p.get("name").getAsString());
+            }
+
+            assertTrue(foundParams.contains("from"), "Should have 'from' parameter");
+            assertTrue(foundParams.contains("days"), "Should have 'days' parameter");
+            assertTrue(foundParams.contains("limit"), "Should have 'limit' parameter");
+        }
+    }
+
+    @Nested
+    class SchemaValidation {
+
+        @Test
+        void statsRecordSchemaMatchesJavaClass() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject statsRecordSchema = schemas.getAsJsonObject("StatsRecord");
+            JsonObject properties = statsRecordSchema.getAsJsonObject("properties");
+
+            // Get all fields from StatsRecord class
+            Set<String> expectedFields = new HashSet<>();
+            for (Field field : de.nurrobin.smpstats.StatsRecord.class.getDeclaredFields()) {
+                expectedFields.add(field.getName());
+            }
+
+            Set<String> schemaFields = properties.keySet();
+
+            assertEquals(expectedFields, schemaFields,
+                    "StatsRecord schema fields should match Java class fields");
+        }
+
+        @Test
+        void momentEntrySchemaMatchesJavaClass() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject momentEntrySchema = schemas.getAsJsonObject("MomentEntry");
+            JsonObject properties = momentEntrySchema.getAsJsonObject("properties");
+
+            Set<String> expectedFields = new HashSet<>();
+            for (Field field : de.nurrobin.smpstats.moments.MomentEntry.class.getDeclaredFields()) {
+                expectedFields.add(field.getName());
+            }
+
+            Set<String> schemaFields = properties.keySet();
+
+            assertEquals(expectedFields, schemaFields,
+                    "MomentEntry schema fields should match Java class fields");
+        }
+
+        @Test
+        void heatmapBinSchemaMatchesJavaClass() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject heatmapBinSchema = schemas.getAsJsonObject("HeatmapBin");
+            JsonObject properties = heatmapBinSchema.getAsJsonObject("properties");
+
+            Set<String> expectedFields = Set.of("type", "world", "x", "z", "gridSize", "count");
+            Set<String> schemaFields = properties.keySet();
+
+            assertEquals(expectedFields, schemaFields,
+                    "HeatmapBin schema fields should match Java class fields");
+        }
+
+        @Test
+        void healthSnapshotSchemaMatchesRecord() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject healthSnapshotSchema = schemas.getAsJsonObject("HealthSnapshot");
+            JsonObject properties = healthSnapshotSchema.getAsJsonObject("properties");
+
+            Set<String> expectedFields = new HashSet<>();
+            for (RecordComponent component : de.nurrobin.smpstats.health.HealthSnapshot.class.getRecordComponents()) {
+                expectedFields.add(component.getName());
+            }
+
+            Set<String> schemaFields = properties.keySet();
+
+            assertEquals(expectedFields, schemaFields,
+                    "HealthSnapshot schema fields should match record components");
+        }
+
+        @Test
+        void socialPairSchemaHasAllFields() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject socialPairSchema = schemas.getAsJsonObject("SocialPair");
+            JsonObject properties = socialPairSchema.getAsJsonObject("properties");
+
+            // API response adds name_a and name_b, original record has uuidA, uuidB
+            Set<String> expectedApiFields = Set.of("a", "b", "name_a", "name_b", "seconds",
+                    "shared_kills", "shared_player_kills", "shared_mob_kills");
+            Set<String> schemaFields = properties.keySet();
+
+            assertEquals(expectedApiFields, schemaFields,
+                    "SocialPair schema should have all expected API response fields");
+        }
+
+        @Test
+        void allReferencedSchemasExist() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+
+            Set<String> referencedSchemas = new HashSet<>();
+            collectSchemaReferences(paths, referencedSchemas);
+
+            for (String ref : referencedSchemas) {
+                assertTrue(schemas.has(ref),
+                        "Referenced schema '" + ref + "' should exist in components/schemas");
+            }
+        }
+
+        @Test
+        void nestedHealthSchemasExist() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+
+            assertTrue(schemas.has("HealthWorldBreakdown"), "Should have HealthWorldBreakdown schema");
+            assertTrue(schemas.has("HealthHotChunk"), "Should have HealthHotChunk schema");
+        }
+
+        @Test
+        void healthWorldBreakdownSchemaMatchesRecord() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject schema = schemas.getAsJsonObject("HealthWorldBreakdown");
+            JsonObject properties = schema.getAsJsonObject("properties");
+
+            Set<String> expectedFields = Set.of("chunks", "entities", "hoppers", "redstone");
+            assertEquals(expectedFields, properties.keySet());
+        }
+
+        @Test
+        void healthHotChunkSchemaMatchesRecord() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject schema = schemas.getAsJsonObject("HealthHotChunk");
+            JsonObject properties = schema.getAsJsonObject("properties");
+
+            Set<String> expectedFields = Set.of("world", "x", "z", "entityCount", "tileEntityCount", "topOwner");
+            assertEquals(expectedFields, properties.keySet());
+        }
+
+        private void collectSchemaReferences(JsonElement element, Set<String> refs) {
+            if (element.isJsonObject()) {
+                JsonObject obj = element.getAsJsonObject();
+                if (obj.has("$ref")) {
+                    String ref = obj.get("$ref").getAsString();
+                    if (ref.startsWith("#/components/schemas/")) {
+                        refs.add(ref.substring("#/components/schemas/".length()));
+                    }
+                }
+                for (String key : obj.keySet()) {
+                    collectSchemaReferences(obj.get(key), refs);
+                }
+            } else if (element.isJsonArray()) {
+                for (JsonElement e : element.getAsJsonArray()) {
+                    collectSchemaReferences(e, refs);
+                }
+            }
+        }
+    }
+
+    @Nested
+    class ResponseSchemas {
+
+        @Test
+        void statsPlayerIdReturnsStatsRecordSchema() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject statsPath = paths.getAsJsonObject("/stats/{playerId}");
+            JsonObject responses = statsPath.getAsJsonObject("get").getAsJsonObject("responses");
+            JsonObject ok = responses.getAsJsonObject("200");
+
+            String ref = ok.getAsJsonObject("content")
+                    .getAsJsonObject("application/json")
+                    .getAsJsonObject("schema")
+                    .get("$ref").getAsString();
+
+            assertEquals("#/components/schemas/StatsRecord", ref);
+        }
+
+        @Test
+        void statsAllReturnsArrayOfStatsRecord() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject statsAll = paths.getAsJsonObject("/stats/all");
+            JsonObject responses = statsAll.getAsJsonObject("get").getAsJsonObject("responses");
+            JsonObject ok = responses.getAsJsonObject("200");
+            JsonObject schema = ok.getAsJsonObject("content")
+                    .getAsJsonObject("application/json")
+                    .getAsJsonObject("schema");
+
+            assertEquals("array", schema.get("type").getAsString());
+            assertEquals("#/components/schemas/StatsRecord",
+                    schema.getAsJsonObject("items").get("$ref").getAsString());
+        }
+
+        @Test
+        void onlineReturnsArrayOfStrings() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject online = paths.getAsJsonObject("/online");
+            JsonObject schema = online.getAsJsonObject("get")
+                    .getAsJsonObject("responses")
+                    .getAsJsonObject("200")
+                    .getAsJsonObject("content")
+                    .getAsJsonObject("application/json")
+                    .getAsJsonObject("schema");
+
+            assertEquals("array", schema.get("type").getAsString());
+            assertEquals("string", schema.getAsJsonObject("items").get("type").getAsString());
+        }
+
+        @Test
+        void momentsStreamReturnsEventStream() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject stream = paths.getAsJsonObject("/moments/stream");
+            JsonObject content = stream.getAsJsonObject("get")
+                    .getAsJsonObject("responses")
+                    .getAsJsonObject("200")
+                    .getAsJsonObject("content");
+
+            assertTrue(content.has("text/event-stream"),
+                    "Moments stream should return text/event-stream content type");
+        }
+
+        @Test
+        void heatmapHotspotsReturnsHotspotSchema() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject hotspots = paths.getAsJsonObject("/heatmap/hotspots/{type}");
+            JsonObject schema = hotspots.getAsJsonObject("get")
+                    .getAsJsonObject("responses")
+                    .getAsJsonObject("200")
+                    .getAsJsonObject("content")
+                    .getAsJsonObject("application/json")
+                    .getAsJsonObject("schema");
+
+            assertEquals("#/components/schemas/HeatmapHotspots", schema.get("$ref").getAsString());
+        }
+
+        @Test
+        void errorResponsesUseTextPlain() {
+            JsonObject paths = openApiJson.getAsJsonObject("paths");
+            JsonObject statsPath = paths.getAsJsonObject("/stats/{playerId}");
+            JsonObject responses = statsPath.getAsJsonObject("get").getAsJsonObject("responses");
+
+            // Check 400 response
+            JsonObject badRequest = responses.getAsJsonObject("400");
+            assertTrue(badRequest.getAsJsonObject("content").has("text/plain"));
+
+            // Check 404 response
+            JsonObject notFound = responses.getAsJsonObject("404");
+            assertTrue(notFound.getAsJsonObject("content").has("text/plain"));
+        }
+    }
+
+    @Nested
+    class EdgeCases {
+
+        @Test
+        void handlesNullPluginVersion() {
+            OpenApiDocument docWithNullVersion = new OpenApiDocument(settings, null);
+            String json = docWithNullVersion.toJson();
+
+            // Should not throw, should produce valid JSON
+            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
+            JsonObject info = parsed.getAsJsonObject("info");
+            // Depending on Gson config, version may be missing or null when input is null
+            // Both are acceptable - the key is that the document is still valid JSON
+            if (info.has("version")) {
+                JsonElement version = info.get("version");
+                assertTrue(version.isJsonNull() || version.getAsString() == null);
+            }
+            // Document should still be valid even with null version
+            assertTrue(parsed.has("paths"));
+            assertTrue(parsed.has("components"));
+        }
+
+        @Test
+        void handlesUnknownPluginVersion() {
+            OpenApiDocument docWithUnknown = new OpenApiDocument(settings, "unknown");
+            JsonObject parsed = JsonParser.parseString(docWithUnknown.toJson()).getAsJsonObject();
+
+            assertEquals("unknown", parsed.getAsJsonObject("info").get("version").getAsString());
+        }
+
+        @Test
+        void producesValidJsonOutput() {
+            String json = document.toJson();
+
+            // Should not throw when parsing
+            assertDoesNotThrow(() -> JsonParser.parseString(json));
+
+            // Should be a JSON object
+            assertTrue(JsonParser.parseString(json).isJsonObject());
+        }
+
+        @Test
+        void jsonIsPrettyPrinted() {
+            String json = document.toJson();
+
+            // Pretty printed JSON should contain newlines
+            assertTrue(json.contains("\n"), "JSON output should be pretty-printed");
+        }
+    }
+
+    @Nested
+    class TypeValidation {
+
+        @Test
+        void uuidFieldsHaveCorrectFormat() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+
+            // Check StatsRecord uuid field
+            JsonObject statsRecordUuid = schemas.getAsJsonObject("StatsRecord")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("uuid");
+            assertEquals("string", statsRecordUuid.get("type").getAsString());
+            assertEquals("uuid", statsRecordUuid.get("format").getAsString());
+
+            // Check MomentEntry playerId field
+            JsonObject momentPlayerId = schemas.getAsJsonObject("MomentEntry")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("playerId");
+            assertEquals("string", momentPlayerId.get("type").getAsString());
+            assertEquals("uuid", momentPlayerId.get("format").getAsString());
+        }
+
+        @Test
+        void timestampFieldsHaveInt64Format() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+
+            // Check StatsRecord timestamps
+            JsonObject statsProps = schemas.getAsJsonObject("StatsRecord").getAsJsonObject("properties");
+            assertEquals("int64", statsProps.getAsJsonObject("firstJoin").get("format").getAsString());
+            assertEquals("int64", statsProps.getAsJsonObject("lastJoin").get("format").getAsString());
+            assertEquals("int64", statsProps.getAsJsonObject("playtimeMillis").get("format").getAsString());
+
+            // Check MomentEntry timestamps
+            JsonObject momentProps = schemas.getAsJsonObject("MomentEntry").getAsJsonObject("properties");
+            assertEquals("int64", momentProps.getAsJsonObject("startedAt").get("format").getAsString());
+            assertEquals("int64", momentProps.getAsJsonObject("endedAt").get("format").getAsString());
+        }
+
+        @Test
+        void numericFieldsHaveCorrectTypes() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+            JsonObject statsProps = schemas.getAsJsonObject("StatsRecord").getAsJsonObject("properties");
+
+            // Integer fields
+            assertEquals("integer", statsProps.getAsJsonObject("deaths").get("type").getAsString());
+            assertEquals("integer", statsProps.getAsJsonObject("playerKills").get("type").getAsString());
+            assertEquals("integer", statsProps.getAsJsonObject("mobKills").get("type").getAsString());
+
+            // Number (double) fields
+            assertEquals("number", statsProps.getAsJsonObject("distanceOverworld").get("type").getAsString());
+            assertEquals("number", statsProps.getAsJsonObject("damageDealt").get("type").getAsString());
+        }
+
+        @Test
+        void nullableFieldsAreMarked() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+
+            // StatsRecord.lastDeathCause is nullable
+            JsonObject lastDeathCause = schemas.getAsJsonObject("StatsRecord")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("lastDeathCause");
+            assertTrue(lastDeathCause.has("nullable") && lastDeathCause.get("nullable").getAsBoolean(),
+                    "lastDeathCause should be marked as nullable");
+
+            // MomentEntry.id is nullable
+            JsonObject momentId = schemas.getAsJsonObject("MomentEntry")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("id");
+            assertTrue(momentId.has("nullable") && momentId.get("nullable").getAsBoolean(),
+                    "MomentEntry.id should be marked as nullable");
+
+            // MomentEntry.payload is nullable
+            JsonObject payload = schemas.getAsJsonObject("MomentEntry")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("payload");
+            assertTrue(payload.has("nullable") && payload.get("nullable").getAsBoolean(),
+                    "MomentEntry.payload should be marked as nullable");
+        }
+
+        @Test
+        void arrayFieldsHaveItemsSchema() {
+            JsonObject schemas = openApiJson.getAsJsonObject("components").getAsJsonObject("schemas");
+
+            // StatsRecord.biomesVisited
+            JsonObject biomesVisited = schemas.getAsJsonObject("StatsRecord")
+                    .getAsJsonObject("properties")
+                    .getAsJsonObject("biomesVisited");
+            assertEquals("array", biomesVisited.get("type").getAsString());
+            assertTrue(biomesVisited.has("items"));
+            assertEquals("string", biomesVisited.getAsJsonObject("items").get("type").getAsString());
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces support for serving a machine-readable OpenAPI 3.1 document via the `/openapi.json` endpoint and updates the API documentation to reflect new and improved response fields for several endpoints. The changes enhance external tooling compatibility and provide clearer, more detailed API documentation for users and developers.

**API Documentation and Endpoint Enhancements:**

* Added a new public endpoint `GET /openapi.json` that returns the OpenAPI 3.1 document for the HTTP API, enabling better integration with external tools and clients. This includes a new `OpenApiHandler` and supporting logic in `ApiServer.java`. [[1]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR39) [[2]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR53) [[3]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR64) [[4]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR121-R129) [[5]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR138-R145) [[6]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR486) [[7]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R9) [[8]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R153-R156) [[9]](diffhunk://#diff-184cd41c0fa500ac6ef7894268d24a33f49bc70fa5800bfae0634f809fed713bR221)

**API Response Structure Improvements:**

* Updated heatmap API responses to use `x`, `z`, and `gridSize` fields, clarified the meaning of `count` (now a weighted number), and documented the `/heatmap/hotspots/*` response format.
* Enhanced `/health` endpoint documentation to include new fields: `tps`, `memoryUsed`, `memoryMax`, and `hotChunks`, providing more comprehensive server health metrics.

**Internal Code Quality:**

* Added explicit UTF-8 encoding for JSON responses in `sendJsonString`, ensuring consistent character encoding. [[1]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR21) [[2]](diffhunk://#diff-d3d7b0c4701663362d531c19ca9e082c50603a4c9fdf7db73603ded94dde6b5fR121-R129)

These changes collectively improve the plugin's API usability, documentation clarity, and interoperability with external systems.